### PR TITLE
Update RISC-V mailing list link

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -19,7 +19,7 @@ are [here](http://news.gmane.org/gmane.comp.hardware.lowrisc.devel) and you
 can [subscribe 
 here](http://listmaster.pepperfish.net/cgi-bin/mailman/listinfo/lowrisc-dev-lists.lowrisc.org).  
 There's also relevant discussion on the [RISC-V mailing 
-lists](http://riscv.org/mailinglist.html).
+lists](http://riscv.org/mailing-lists/).
 
 We also have an IRC channel where a number of us as well others interested in 
 lowRISC, RISC-V, and open source hardware hang out. There won't always be 


### PR DESCRIPTION
The link was broken.
